### PR TITLE
Code refactor and partial piecewise movement

### DIFF
--- a/src/game/manager.rs
+++ b/src/game/manager.rs
@@ -65,15 +65,12 @@ impl GameManager {
                     .expect("Failed to read option");
                 option = option.trim().to_string();
 
-                if option == "close" {
-                    leave_game = true;
+                self.perform_command(&option);
+                if option == "exit"{
                     break;
                 }
-
-                if option != "exit" {
-                    self.perform_command(&option);
-                }
-                else {
+                else if option == "close" {
+                    leave_game = true;
                     break;
                 }
             }
@@ -132,8 +129,7 @@ impl MenuFunctions for GameManager {
                 GameManager::show_menu();
             }
             "exit" => println!("Exiting menu.."),
-            // TODO: prompt for save
-            "close" => println!("Closing game.."),
+            "close" => self.begin_close(),
             _ => println!("'{}' is not a valid option", option),
         }
     }
@@ -329,5 +325,27 @@ impl MenuFunctions for GameManager {
             .expect("Failed to create the save");
         save_file.write_all(board_state.as_bytes())
             .expect("Failed to write the save to the file");
+    }
+
+    fn begin_close(&self) {
+        println!("Do you wish to save before closing? (Yy/Nn):");
+        let mut choice = String::new();
+        loop {
+            io::stdin().read_line(&mut choice)
+                .expect("Failed to read choice");
+            choice = choice.trim().to_string();
+
+            if choice != "Y" && choice != "y" && choice != "N" && choice != "n" {
+                println!("Invalid choice. Type 'Y/y' or 'N/n'");
+                choice = String::new();
+            }
+            else {
+                break;
+            }
+        }
+
+        if choice == "Y" || choice == "y" {
+            self.export_game();
+        }
     }
 }

--- a/src/game/manager.rs
+++ b/src/game/manager.rs
@@ -27,6 +27,8 @@ impl GameManager {
     }
 
     pub fn run(&mut self) -> bool {
+        let mut leave_game = false;
+
         self.display_board();
 
         let side_index = self.current_side.to_index();
@@ -63,6 +65,11 @@ impl GameManager {
                     .expect("Failed to read option");
                 option = option.trim().to_string();
 
+                if option == "close" {
+                    leave_game = true;
+                    break;
+                }
+
                 if option != "exit" {
                     self.perform_command(&option);
                 }
@@ -76,7 +83,7 @@ impl GameManager {
         print!("{}[2J", 27 as char);
         print!("{}[1;1H", 27 as char);
 
-        return false;
+        return leave_game;
     }
 
     fn display_board(&self) {
@@ -125,6 +132,8 @@ impl MenuFunctions for GameManager {
                 GameManager::show_menu();
             }
             "exit" => println!("Exiting menu.."),
+            // TODO: prompt for save
+            "close" => println!("Closing game.."),
             _ => println!("'{}' is not a valid option", option),
         }
     }
@@ -139,6 +148,7 @@ impl MenuFunctions for GameManager {
         println!("\"export\" => saves the current game");
         println!("\"clear\"  => clears the screen to show a clean menu");
         println!("\"exit\"   => return to the game");
+        println!("\"close\"  => close the chess game");
         println!("-- END --");
         // TODO: add new print for each available command
     }

--- a/src/game/manager.rs
+++ b/src/game/manager.rs
@@ -40,9 +40,8 @@ impl GameManager {
             println!("\nBlack Move:");
         }
 
-        let (initial_position, result_position) = self.players[side_index].move_input();
-        // returns -1 if user wishes to enter the menu
-        if initial_position.x != -1 {
+        let player_move = self.players[side_index].move_input();
+        if let Some((initial_position, result_position)) = player_move {
             if self.players[side_index].piece_at_coord(&result_position) {
                 // TODO: print piece taken inform
             }
@@ -52,7 +51,7 @@ impl GameManager {
             self.chess_board.update_board(self.players[0].pieces(), self.players[1].pieces());
             self.current_side.switch();
         }
-        else {
+        else if let None = player_move {
             // clear the console screen through ANSI codes
             print!("{}[2J", 27 as char);
             print!("{}[1;1H", 27 as char);

--- a/src/game/manager.rs
+++ b/src/game/manager.rs
@@ -42,6 +42,16 @@ impl GameManager {
 
         let player_move = self.players[side_index].move_input();
         if let Some((initial_position, result_position)) = player_move {
+            self.players[side_index].generate_possible_moves(&initial_position);
+            
+            // TODO: understand borrowing temp fix clone
+            let player_pieces = self.players[side_index].pieces().clone();
+            let opponent_pieces = self.players[!side_index].pieces().clone();
+            self.players[side_index].prune_possible_moves(player_pieces, false);
+            self.players[side_index].prune_possible_moves(opponent_pieces, true);
+
+            // TODO: check for moves on enemy piece not registered as possible capture
+
             // TODO: side_index might not be correct. might be opposite
             if let Some(_piece) = self.players[side_index].get_piece(&result_position) {
                 // TODO: print piece taken inform

--- a/src/game/manager.rs
+++ b/src/game/manager.rs
@@ -41,8 +41,8 @@ impl GameManager {
         }
 
         let (initial_position, result_position) = self.players[side_index].move_input();
-        // returns -2 if user wishes to enter the menu
-        if initial_position.x != -2 {
+        // returns -1 if user wishes to enter the menu
+        if initial_position.x != -1 {
             if self.players[side_index].piece_at_coord(&result_position) {
                 // TODO: print piece taken inform
             }

--- a/src/game/manager.rs
+++ b/src/game/manager.rs
@@ -42,7 +42,8 @@ impl GameManager {
 
         let player_move = self.players[side_index].move_input();
         if let Some((initial_position, result_position)) = player_move {
-            if self.players[side_index].piece_at_coord(&result_position) {
+            // TODO: side_index might not be correct. might be opposite
+            if let Some(_piece) = self.players[side_index].get_piece(&result_position) {
                 // TODO: print piece taken inform
             }
 

--- a/src/game/manager.rs
+++ b/src/game/manager.rs
@@ -194,6 +194,7 @@ impl MenuFunctions for GameManager {
         let file_contents = fs::read_to_string(save_file_path)
             .expect("Failed to read the save file.");
 
+        // TODO: check if a pawn has its first move or not
         self.read_save(&file_contents);
 
         self.chess_board.update_board(self.players[0].pieces(), self.players[1].pieces());
@@ -242,6 +243,7 @@ impl MenuFunctions for GameManager {
                     if let Some(piece) = PieceType::convert(ch) {
                         let side = piece.side();
                         let pos = Position { x: cell, y: row };
+                        // TODO: change first move if not at specific y-coord
                         if side == Side::WHITE {
                             self.players[0].add_piece(pos, piece);
                         }

--- a/src/game/menu.rs
+++ b/src/game/menu.rs
@@ -21,4 +21,6 @@ pub trait MenuFunctions {
     fn export_game(&self);
     fn export_board(&self) -> String;
     fn create_save(game_state: &str);
+
+    fn begin_close(&self);
 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -2,5 +2,6 @@ pub mod manager;
 pub mod menu;
 pub mod side;
 pub mod chess_board;
+pub mod move_direction;
 pub mod player;
 pub mod pieces;

--- a/src/game/move_direction.rs
+++ b/src/game/move_direction.rs
@@ -1,0 +1,10 @@
+pub enum MoveDirection {
+    UP,
+    DOWN,
+    LEFT,
+    RIGHT,
+    UP_LEFT,
+    UP_RIGHT,
+    DOWN_LEFT,
+    DOWN_RIGHT,
+}

--- a/src/game/pieces/bishop.rs
+++ b/src/game/pieces/bishop.rs
@@ -19,9 +19,9 @@ impl Bishop {
 }
 
 impl Piece for Bishop {
-    fn validate_move(old_pos: &Position, new_pos: &Position) -> bool {
-        // TODO: generate all possible moves for this piece. Compare with move.
-        // TODO: Turn move to Position, use position comparison
-        return true;
+    fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position> {
+        let moves = Vec::new();
+
+        return moves;
     }
 }

--- a/src/game/pieces/bishop.rs
+++ b/src/game/pieces/bishop.rs
@@ -41,9 +41,48 @@ impl Piece for Bishop {
 
     }
 
-    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
-        let invalids = HashSet::new();
+    fn invalid_moves(&self, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
+        let invalids: HashSet<Position>;
         let dir = self.find_prune_direction(pos, x_diff, y_diff);
+
+        invalids = match dir {
+            MoveDirection::UP_RIGHT => Bishop::prune_moves(pos, 8, 8),
+            MoveDirection::DOWN_RIGHT => Bishop::prune_moves(pos, 8, 0),
+            MoveDirection::UP_LEFT => Bishop::prune_moves(pos, 0, 8),
+            MoveDirection::DOWN_LEFT => Bishop::prune_moves(pos, 0, 0),
+            _ => HashSet::new(),
+        };
+
+        return invalids;
+    }
+
+    // TODO: could probably reuse for move generation
+    fn prune_moves(initial_pos: &Position, row_max: i8, col_max: i8) -> HashSet<Position> {
+        let (row_start, row_end) = (initial_pos.x, row_max);
+        let (col_start, col_end) = (initial_pos.y, col_max);
+        
+        let row_range = if row_start <= row_end {
+            row_start..row_end
+        }
+        else {
+            row_end..row_start
+        };
+
+        let col_range = if col_start <= col_end {
+            col_start..col_end
+        }
+        else {
+            col_end..col_start
+        };
+
+        let mut invalids: HashSet<Position> = HashSet::new();
+        for row in row_range {
+            for col in col_range.clone() {
+                let invalid_move = Position { x: row, y: col };
+                invalids.insert(invalid_move);
+
+            }
+        }
 
         return invalids;
     }

--- a/src/game/pieces/bishop.rs
+++ b/src/game/pieces/bishop.rs
@@ -1,6 +1,9 @@
 use crate::game::side::Side;
 use crate::game::pieces::piece::*;
 
+use std::collections::HashSet;
+
+#[derive(Clone)]
 pub struct Bishop {
     pub icon: char,
 
@@ -19,8 +22,8 @@ impl Bishop {
 }
 
 impl Piece for Bishop {
-    fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position> {
-        let moves = Vec::new();
+    fn possible_moves(&mut self, initial_pos: &Position) -> HashSet<Position> {
+        let moves = HashSet::new();
 
         return moves;
     }

--- a/src/game/pieces/bishop.rs
+++ b/src/game/pieces/bishop.rs
@@ -19,7 +19,7 @@ impl Bishop {
 }
 
 impl Piece for Bishop {
-    fn validate_move(new_move: &str) -> bool {
+    fn validate_move(old_pos: &Position, new_pos: &Position) -> bool {
         // TODO: generate all possible moves for this piece. Compare with move.
         // TODO: Turn move to Position, use position comparison
         return true;

--- a/src/game/pieces/bishop.rs
+++ b/src/game/pieces/bishop.rs
@@ -29,15 +29,21 @@ impl Piece for Bishop {
         return moves;
     }
 
-    fn find_prune_direction(&self, pos: &Position, x_diff: u8, y_diff: u8) -> MoveDirection {
-        let dir = MoveDirection::UP;
+    fn find_prune_direction(&self, pos: &Position, x_diff: i8, y_diff: i8) -> MoveDirection {
+        let dir: MoveDirection;
+        
+        if x_diff < 0 && y_diff < 0 { dir = MoveDirection::UP_RIGHT; }
+        else if x_diff < 0 && y_diff > 0 { dir = MoveDirection::DOWN_RIGHT; }
+        else if x_diff > 0 && y_diff < 0 { dir = MoveDirection::UP_LEFT; }
+        else { dir = MoveDirection::DOWN_LEFT; }
 
         return dir;
 
     }
 
-    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position> {
+    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
         let invalids = HashSet::new();
+        let dir = self.find_prune_direction(pos, x_diff, y_diff);
 
         return invalids;
     }

--- a/src/game/pieces/bishop.rs
+++ b/src/game/pieces/bishop.rs
@@ -1,5 +1,6 @@
 use crate::game::side::Side;
 use crate::game::pieces::piece::*;
+use crate::game::move_direction::MoveDirection;
 
 use std::collections::HashSet;
 
@@ -26,5 +27,18 @@ impl Piece for Bishop {
         let moves = HashSet::new();
 
         return moves;
+    }
+
+    fn find_prune_direction(&self, pos: &Position, x_diff: u8, y_diff: u8) -> MoveDirection {
+        let dir = MoveDirection::UP;
+
+        return dir;
+
+    }
+
+    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position> {
+        let invalids = HashSet::new();
+
+        return invalids;
     }
 }

--- a/src/game/pieces/king.rs
+++ b/src/game/pieces/king.rs
@@ -19,9 +19,9 @@ impl King {
 }
 
 impl Piece for King {
-    fn validate_move(old_pos: &Position, new_pos: &Position) -> bool {
-        // TODO: generate all possible moves for this piece. Compare with move.
-        // TODO: Turn move to Position, use position comparison
-        return true;
+    fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position> {
+        let moves = Vec::new();
+
+        return moves;
     }
 }

--- a/src/game/pieces/king.rs
+++ b/src/game/pieces/king.rs
@@ -29,14 +29,14 @@ impl Piece for King {
         return moves;
     }
 
-    fn find_prune_direction(&self, pos: &Position, x_diff: u8, y_diff: u8) -> MoveDirection {
+    fn find_prune_direction(&self, pos: &Position, x_diff: i8, y_diff: i8) -> MoveDirection {
         let dir = MoveDirection::UP;
 
         return dir;
 
     }
 
-    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position> {
+    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
         let invalids = HashSet::new();
 
         return invalids;

--- a/src/game/pieces/king.rs
+++ b/src/game/pieces/king.rs
@@ -1,6 +1,9 @@
 use crate::game::side::Side;
 use crate::game::pieces::piece::*;
 
+use std::collections::HashSet;
+
+#[derive(Clone)]
 pub struct King {
     pub icon: char,
 
@@ -19,8 +22,8 @@ impl King {
 }
 
 impl Piece for King {
-    fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position> {
-        let moves = Vec::new();
+    fn possible_moves(&mut self, initial_pos: &Position) -> HashSet<Position> {
+        let moves = HashSet::new();
 
         return moves;
     }

--- a/src/game/pieces/king.rs
+++ b/src/game/pieces/king.rs
@@ -19,7 +19,7 @@ impl King {
 }
 
 impl Piece for King {
-    fn validate_move(new_move: &str) -> bool {
+    fn validate_move(old_pos: &Position, new_pos: &Position) -> bool {
         // TODO: generate all possible moves for this piece. Compare with move.
         // TODO: Turn move to Position, use position comparison
         return true;

--- a/src/game/pieces/king.rs
+++ b/src/game/pieces/king.rs
@@ -1,5 +1,6 @@
 use crate::game::side::Side;
 use crate::game::pieces::piece::*;
+use crate::game::move_direction::MoveDirection;
 
 use std::collections::HashSet;
 
@@ -26,5 +27,18 @@ impl Piece for King {
         let moves = HashSet::new();
 
         return moves;
+    }
+
+    fn find_prune_direction(&self, pos: &Position, x_diff: u8, y_diff: u8) -> MoveDirection {
+        let dir = MoveDirection::UP;
+
+        return dir;
+
+    }
+
+    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position> {
+        let invalids = HashSet::new();
+
+        return invalids;
     }
 }

--- a/src/game/pieces/king.rs
+++ b/src/game/pieces/king.rs
@@ -36,8 +36,14 @@ impl Piece for King {
 
     }
 
-    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
+    fn invalid_moves(&self, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
         let invalids = HashSet::new();
+
+        return invalids;
+    }
+
+    fn prune_moves(initial_pos: &Position, row_max: i8, col_max: i8) -> HashSet<Position> {
+        let mut invalids: HashSet<Position> = HashSet::new();
 
         return invalids;
     }

--- a/src/game/pieces/knight.rs
+++ b/src/game/pieces/knight.rs
@@ -19,7 +19,7 @@ impl Knight {
 }
 
 impl Piece for Knight {
-    fn validate_move(new_move: &str) -> bool {
+    fn validate_move(old_pos: &Position, new_pos: &Position) -> bool {
         // TODO: generate all possible moves for this piece. Compare with move.
         // TODO: Turn move to Position, use position comparison
         return true;

--- a/src/game/pieces/knight.rs
+++ b/src/game/pieces/knight.rs
@@ -19,9 +19,9 @@ impl Knight {
 }
 
 impl Piece for Knight {
-    fn validate_move(old_pos: &Position, new_pos: &Position) -> bool {
-        // TODO: generate all possible moves for this piece. Compare with move.
-        // TODO: Turn move to Position, use position comparison
-        return true;
+    fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position> {
+        let moves = Vec::new();
+
+        return moves;
     }
 }

--- a/src/game/pieces/knight.rs
+++ b/src/game/pieces/knight.rs
@@ -36,8 +36,14 @@ impl Piece for Knight {
 
     }
 
-    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
+    fn invalid_moves(&self, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
         let invalids = HashSet::new();
+
+        return invalids;
+    }
+
+    fn prune_moves(initial_pos: &Position, row_max: i8, col_max: i8) -> HashSet<Position> {
+        let mut invalids: HashSet<Position> = HashSet::new();
 
         return invalids;
     }

--- a/src/game/pieces/knight.rs
+++ b/src/game/pieces/knight.rs
@@ -1,6 +1,9 @@
 use crate::game::side::Side;
 use crate::game::pieces::piece::*;
 
+use std::collections::HashSet;
+
+#[derive(Clone)]
 pub struct Knight {
     pub icon: char,
 
@@ -19,8 +22,8 @@ impl Knight {
 }
 
 impl Piece for Knight {
-    fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position> {
-        let moves = Vec::new();
+    fn possible_moves(&mut self, initial_pos: &Position) -> HashSet<Position> {
+        let moves = HashSet::new();
 
         return moves;
     }

--- a/src/game/pieces/knight.rs
+++ b/src/game/pieces/knight.rs
@@ -1,5 +1,6 @@
 use crate::game::side::Side;
 use crate::game::pieces::piece::*;
+use crate::game::move_direction::MoveDirection;
 
 use std::collections::HashSet;
 
@@ -26,5 +27,18 @@ impl Piece for Knight {
         let moves = HashSet::new();
 
         return moves;
+    }
+
+    fn find_prune_direction(&self, pos: &Position, x_diff: u8, y_diff: u8) -> MoveDirection {
+        let dir = MoveDirection::UP;
+
+        return dir;
+
+    }
+
+    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position> {
+        let invalids = HashSet::new();
+
+        return invalids;
     }
 }

--- a/src/game/pieces/knight.rs
+++ b/src/game/pieces/knight.rs
@@ -29,14 +29,14 @@ impl Piece for Knight {
         return moves;
     }
 
-    fn find_prune_direction(&self, pos: &Position, x_diff: u8, y_diff: u8) -> MoveDirection {
+    fn find_prune_direction(&self, pos: &Position, x_diff: i8, y_diff: i8) -> MoveDirection {
         let dir = MoveDirection::UP;
 
         return dir;
 
     }
 
-    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position> {
+    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
         let invalids = HashSet::new();
 
         return invalids;

--- a/src/game/pieces/pawn.rs
+++ b/src/game/pieces/pawn.rs
@@ -40,8 +40,14 @@ impl Piece for Pawn {
 
     }
 
-    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
+    fn invalid_moves(&self, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
         let invalids = HashSet::new();
+
+        return invalids;
+    }
+
+    fn prune_moves(initial_pos: &Position, row_max: i8, col_max: i8) -> HashSet<Position> {
+        let mut invalids: HashSet<Position> = HashSet::new();
 
         return invalids;
     }

--- a/src/game/pieces/pawn.rs
+++ b/src/game/pieces/pawn.rs
@@ -19,7 +19,7 @@ impl Pawn {
 }
 
 impl Piece for Pawn {
-    fn validate_move(new_move: &str) -> bool {
+    fn validate_move(old_pos: &Position, new_pos: &Position) -> bool {
         // TODO: generate all possible moves for this piece. Compare with move.
         // TODO: Turn move to Position, use position comparison
         return true;

--- a/src/game/pieces/pawn.rs
+++ b/src/game/pieces/pawn.rs
@@ -3,8 +3,9 @@ use crate::game::pieces::piece::*;
 
 pub struct Pawn {
     pub icon: char,
-
     pub side: Side,
+
+    first_move: bool,
 }
 
 impl Pawn {
@@ -13,15 +14,16 @@ impl Pawn {
             Side::WHITE => 'P',
             Side::BLACK => 'p',
         };
+        let first_move = true;
 
-        Pawn { icon, side }
+        Pawn { icon, side, first_move }
     }
 }
 
 impl Piece for Pawn {
-    fn validate_move(old_pos: &Position, new_pos: &Position) -> bool {
-        // TODO: generate all possible moves for this piece. Compare with move.
-        // TODO: Turn move to Position, use position comparison
-        return true;
+    fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position> {
+        let moves = Vec::new();
+
+        return moves;
     }
 }

--- a/src/game/pieces/pawn.rs
+++ b/src/game/pieces/pawn.rs
@@ -22,7 +22,25 @@ impl Pawn {
 
 impl Piece for Pawn {
     fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position> {
-        let moves = Vec::new();
+        let mut moves = Vec::new();
+        let increment;
+        if self.side == Side::WHITE {
+            increment = 1;
+        }
+        else {
+            increment = -1;
+        }
+
+        if self.first_move {
+            let (new_x, new_y) = (initial_pos.x, initial_pos.y + (2 * increment));
+            let new_move = Position{ x: new_x, y: new_y };
+            moves.push(new_move);
+            self.first_move = false;
+        }
+
+        let (new_x, new_y) = (initial_pos.x, initial_pos.y + increment);
+        let new_move = Position{ x: new_x, y: new_y };
+        moves.push(new_move);
 
         return moves;
     }

--- a/src/game/pieces/pawn.rs
+++ b/src/game/pieces/pawn.rs
@@ -33,14 +33,14 @@ impl Piece for Pawn {
         return moves;
     }
 
-    fn find_prune_direction(&self, pos: &Position, x_diff: u8, y_diff: u8) -> MoveDirection {
+    fn find_prune_direction(&self, pos: &Position, x_diff: i8, y_diff: i8) -> MoveDirection {
         let dir = MoveDirection::UP;
 
         return dir;
 
     }
 
-    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position> {
+    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
         let invalids = HashSet::new();
 
         return invalids;

--- a/src/game/pieces/pawn.rs
+++ b/src/game/pieces/pawn.rs
@@ -1,6 +1,9 @@
 use crate::game::side::Side;
 use crate::game::pieces::piece::*;
 
+use std::collections::HashSet;
+
+#[derive(Clone)]
 pub struct Pawn {
     pub icon: char,
     pub side: Side,
@@ -21,26 +24,10 @@ impl Pawn {
 }
 
 impl Piece for Pawn {
-    fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position> {
-        let mut moves = Vec::new();
-        let increment;
-        if self.side == Side::WHITE {
-            increment = 1;
-        }
-        else {
-            increment = -1;
-        }
-
-        if self.first_move {
-            let (new_x, new_y) = (initial_pos.x, initial_pos.y + (2 * increment));
-            let new_move = Position{ x: new_x, y: new_y };
-            moves.push(new_move);
-            self.first_move = false;
-        }
-
-        let (new_x, new_y) = (initial_pos.x, initial_pos.y + increment);
-        let new_move = Position{ x: new_x, y: new_y };
-        moves.push(new_move);
+    // TODO: return tuple (standard, capture), other pieces has this duplicate, see if can check
+    // TODO: ^ see if can check equality for less checks
+    fn possible_moves(&mut self, initial_pos: &Position) -> HashSet<Position> {
+        let moves = HashSet::new();
 
         return moves;
     }

--- a/src/game/pieces/pawn.rs
+++ b/src/game/pieces/pawn.rs
@@ -1,5 +1,6 @@
 use crate::game::side::Side;
 use crate::game::pieces::piece::*;
+use crate::game::move_direction::MoveDirection;
 
 use std::collections::HashSet;
 
@@ -30,5 +31,18 @@ impl Piece for Pawn {
         let moves = HashSet::new();
 
         return moves;
+    }
+
+    fn find_prune_direction(&self, pos: &Position, x_diff: u8, y_diff: u8) -> MoveDirection {
+        let dir = MoveDirection::UP;
+
+        return dir;
+
+    }
+
+    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position> {
+        let invalids = HashSet::new();
+
+        return invalids;
     }
 }

--- a/src/game/pieces/piece.rs
+++ b/src/game/pieces/piece.rs
@@ -29,6 +29,7 @@ pub trait Piece {
 
     fn possible_moves(&mut self, initial_pos: &Position) -> HashSet<Position>;
 
-    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position>;
+    fn invalid_moves(&self, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position>;
     fn find_prune_direction(&self, pos: &Position, x_diff: i8, y_diff: i8) -> MoveDirection;
+    fn prune_moves(initial_pos: &Position, row_max: i8, col_max: i8) -> HashSet<Position>;
 }

--- a/src/game/pieces/piece.rs
+++ b/src/game/pieces/piece.rs
@@ -5,5 +5,5 @@ pub struct Position {
 }
 
 pub trait Piece {
-    fn validate_move(new_move: &str) -> bool;
+    fn validate_move(old_pos: &Position, new_pos: &Position) -> bool;
 }

--- a/src/game/pieces/piece.rs
+++ b/src/game/pieces/piece.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct Position {
     pub x: i8,
@@ -5,6 +7,9 @@ pub struct Position {
 }
 
 pub trait Piece {
+    // TODO: check standard and capture moves
+    // TODO: ^ if the same, ignore
+    // TODO: ^ if different, dont compare capture moves?
     fn validate_move(&mut self, old_pos: &Position, new_pos: &Position) -> bool {
         let mut valid = false;
         let moves = self.possible_moves(old_pos);
@@ -20,5 +25,5 @@ pub trait Piece {
         return valid;
     }
 
-    fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position>;
+    fn possible_moves(&mut self, initial_pos: &Position) -> HashSet<Position>;
 }

--- a/src/game/pieces/piece.rs
+++ b/src/game/pieces/piece.rs
@@ -1,3 +1,5 @@
+use crate::game::move_direction::MoveDirection;
+
 use std::collections::HashSet;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
@@ -26,4 +28,7 @@ pub trait Piece {
     }
 
     fn possible_moves(&mut self, initial_pos: &Position) -> HashSet<Position>;
+
+    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position>;
+    fn find_prune_direction(&self, pos: &Position, x_diff: u8, y_diff: u8) -> MoveDirection;
 }

--- a/src/game/pieces/piece.rs
+++ b/src/game/pieces/piece.rs
@@ -5,5 +5,20 @@ pub struct Position {
 }
 
 pub trait Piece {
-    fn validate_move(old_pos: &Position, new_pos: &Position) -> bool;
+    fn validate_move(&mut self, old_pos: &Position, new_pos: &Position) -> bool {
+        let mut valid = false;
+        let moves = self.possible_moves(old_pos);
+
+        for potential_move in moves.iter() {
+            if new_pos.x == potential_move.x && new_pos.y == potential_move.y {
+                valid = true;
+                break;
+            }
+
+        }
+
+        return valid;
+    }
+
+    fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position>;
 }

--- a/src/game/pieces/piece.rs
+++ b/src/game/pieces/piece.rs
@@ -29,6 +29,6 @@ pub trait Piece {
 
     fn possible_moves(&mut self, initial_pos: &Position) -> HashSet<Position>;
 
-    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position>;
-    fn find_prune_direction(&self, pos: &Position, x_diff: u8, y_diff: u8) -> MoveDirection;
+    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position>;
+    fn find_prune_direction(&self, pos: &Position, x_diff: i8, y_diff: i8) -> MoveDirection;
 }

--- a/src/game/pieces/piece_type.rs
+++ b/src/game/pieces/piece_type.rs
@@ -1,9 +1,13 @@
+use crate::game::pieces::piece::Piece;
+
 use crate::game::pieces::king::King;
 use crate::game::pieces::queen::Queen;
 use crate::game::pieces::rook::Rook;
 use crate::game::pieces::bishop::Bishop;
 use crate::game::pieces::knight::Knight;
 use crate::game::pieces::pawn::Pawn;
+
+use crate::game::pieces::Position;
 use crate::game::side::Side;
 
 pub enum PieceType {
@@ -58,5 +62,19 @@ impl PieceType {
         };
 
         return s;
+    }
+
+    pub fn validate_move(&self, old_pos: &Position, new_pos: &Position) -> bool {
+        let valid: bool;
+        match self {
+            PieceType::King(_) => valid = King::validate_move(old_pos, new_pos),
+            PieceType::Queen(_) => valid = Queen::validate_move(old_pos, new_pos),
+            PieceType::Rook(_) => valid = Rook::validate_move(old_pos, new_pos),
+            PieceType::Bishop(_) => valid = Bishop::validate_move(old_pos, new_pos),
+            PieceType::Knight(_) => valid = Knight::validate_move(old_pos, new_pos),
+            PieceType::Pawn(_) => valid = Pawn::validate_move(old_pos, new_pos),
+        }
+
+        return valid;
     }
 }

--- a/src/game/pieces/piece_type.rs
+++ b/src/game/pieces/piece_type.rs
@@ -9,6 +9,7 @@ use crate::game::pieces::pawn::Pawn;
 
 use crate::game::pieces::Position;
 use crate::game::side::Side;
+use crate::game::move_direction::MoveDirection;
 
 use std::collections::HashSet;
 
@@ -89,6 +90,17 @@ impl PieceType {
             PieceType::Bishop(bishop) => bishop.possible_moves(pos),
             PieceType::Knight(knight) => knight.possible_moves(pos),
             PieceType::Pawn(pawn) => pawn.possible_moves(pos),
+        };
+    }
+
+    pub fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position> {
+        return match self {
+            PieceType::King(king) => king.invalid_moves(possible_moves, pos, x_diff, y_diff),
+            PieceType::Queen(queen) => queen.invalid_moves(possible_moves, pos, x_diff, y_diff),
+            PieceType::Rook(rook) => rook.invalid_moves(possible_moves, pos, x_diff, y_diff),
+            PieceType::Bishop(bishop) => bishop.invalid_moves(possible_moves, pos, x_diff, y_diff),
+            PieceType::Knight(knight) => knight.invalid_moves(possible_moves, pos, x_diff, y_diff),
+            PieceType::Pawn(pawn) => pawn.invalid_moves(possible_moves, pos, x_diff, y_diff),
         };
     }
 }

--- a/src/game/pieces/piece_type.rs
+++ b/src/game/pieces/piece_type.rs
@@ -64,15 +64,15 @@ impl PieceType {
         return s;
     }
 
-    pub fn validate_move(&self, old_pos: &Position, new_pos: &Position) -> bool {
+    pub fn validate_move(&mut self, old_pos: &Position, new_pos: &Position) -> bool {
         let valid: bool;
         match self {
-            PieceType::King(_) => valid = King::validate_move(old_pos, new_pos),
-            PieceType::Queen(_) => valid = Queen::validate_move(old_pos, new_pos),
-            PieceType::Rook(_) => valid = Rook::validate_move(old_pos, new_pos),
-            PieceType::Bishop(_) => valid = Bishop::validate_move(old_pos, new_pos),
-            PieceType::Knight(_) => valid = Knight::validate_move(old_pos, new_pos),
-            PieceType::Pawn(_) => valid = Pawn::validate_move(old_pos, new_pos),
+            PieceType::King(king) => valid = king.validate_move(old_pos, new_pos),
+            PieceType::Queen(queen) => valid = queen.validate_move(old_pos, new_pos),
+            PieceType::Rook(rook) => valid = rook.validate_move(old_pos, new_pos),
+            PieceType::Bishop(bishop) => valid = bishop.validate_move(old_pos, new_pos),
+            PieceType::Knight(knight) => valid = knight.validate_move(old_pos, new_pos),
+            PieceType::Pawn(pawn) => valid = pawn.validate_move(old_pos, new_pos),
         }
 
         return valid;

--- a/src/game/pieces/piece_type.rs
+++ b/src/game/pieces/piece_type.rs
@@ -93,7 +93,7 @@ impl PieceType {
         };
     }
 
-    pub fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position> {
+    pub fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
         return match self {
             PieceType::King(king) => king.invalid_moves(possible_moves, pos, x_diff, y_diff),
             PieceType::Queen(queen) => queen.invalid_moves(possible_moves, pos, x_diff, y_diff),

--- a/src/game/pieces/piece_type.rs
+++ b/src/game/pieces/piece_type.rs
@@ -10,6 +10,9 @@ use crate::game::pieces::pawn::Pawn;
 use crate::game::pieces::Position;
 use crate::game::side::Side;
 
+use std::collections::HashSet;
+
+#[derive(Clone)]
 pub enum PieceType {
     King(King),
     Queen(Queen),
@@ -76,5 +79,16 @@ impl PieceType {
         }
 
         return valid;
+    }
+
+    pub fn possible_moves(&mut self, pos: &Position) -> HashSet<Position> {
+        return match self {
+            PieceType::King(king) => king.possible_moves(pos),
+            PieceType::Queen(queen) => queen.possible_moves(pos),
+            PieceType::Rook(rook) => rook.possible_moves(pos),
+            PieceType::Bishop(bishop) => bishop.possible_moves(pos),
+            PieceType::Knight(knight) => knight.possible_moves(pos),
+            PieceType::Pawn(pawn) => pawn.possible_moves(pos),
+        };
     }
 }

--- a/src/game/pieces/piece_type.rs
+++ b/src/game/pieces/piece_type.rs
@@ -93,14 +93,14 @@ impl PieceType {
         };
     }
 
-    pub fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
+    pub fn invalid_moves(&self, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
         return match self {
-            PieceType::King(king) => king.invalid_moves(possible_moves, pos, x_diff, y_diff),
-            PieceType::Queen(queen) => queen.invalid_moves(possible_moves, pos, x_diff, y_diff),
-            PieceType::Rook(rook) => rook.invalid_moves(possible_moves, pos, x_diff, y_diff),
-            PieceType::Bishop(bishop) => bishop.invalid_moves(possible_moves, pos, x_diff, y_diff),
-            PieceType::Knight(knight) => knight.invalid_moves(possible_moves, pos, x_diff, y_diff),
-            PieceType::Pawn(pawn) => pawn.invalid_moves(possible_moves, pos, x_diff, y_diff),
+            PieceType::King(king) => king.invalid_moves(pos, x_diff, y_diff),
+            PieceType::Queen(queen) => queen.invalid_moves(pos, x_diff, y_diff),
+            PieceType::Rook(rook) => rook.invalid_moves(pos, x_diff, y_diff),
+            PieceType::Bishop(bishop) => bishop.invalid_moves(pos, x_diff, y_diff),
+            PieceType::Knight(knight) => knight.invalid_moves(pos, x_diff, y_diff),
+            PieceType::Pawn(pawn) => pawn.invalid_moves(pos, x_diff, y_diff),
         };
     }
 }

--- a/src/game/pieces/queen.rs
+++ b/src/game/pieces/queen.rs
@@ -1,6 +1,9 @@
 use crate::game::side::Side;
 use crate::game::pieces::piece::*;
 
+use std::collections::HashSet;
+
+#[derive(Clone)]
 pub struct Queen {
     pub icon: char,
 
@@ -19,8 +22,8 @@ impl Queen {
 }
 
 impl Piece for Queen {
-    fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position> {
-        let moves = Vec::new();
+    fn possible_moves(&mut self, initial_pos: &Position) -> HashSet<Position> {
+        let moves = HashSet::new();
 
         return moves;
     }

--- a/src/game/pieces/queen.rs
+++ b/src/game/pieces/queen.rs
@@ -19,9 +19,9 @@ impl Queen {
 }
 
 impl Piece for Queen {
-    fn validate_move(old_pos: &Position, new_pos: &Position) -> bool {
-        // TODO: generate all possible moves for this piece. Compare with move.
-        // TODO: Turn move to Position, use position comparison
-        return true;
+    fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position> {
+        let moves = Vec::new();
+
+        return moves;
     }
 }

--- a/src/game/pieces/queen.rs
+++ b/src/game/pieces/queen.rs
@@ -29,14 +29,14 @@ impl Piece for Queen {
         return moves;
     }
 
-    fn find_prune_direction(&self, pos: &Position, x_diff: u8, y_diff: u8) -> MoveDirection {
+    fn find_prune_direction(&self, pos: &Position, x_diff: i8, y_diff: i8) -> MoveDirection {
         let dir = MoveDirection::UP;
 
         return dir;
 
     }
 
-    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position> {
+    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
         let invalids = HashSet::new();
 
         return invalids;

--- a/src/game/pieces/queen.rs
+++ b/src/game/pieces/queen.rs
@@ -36,8 +36,14 @@ impl Piece for Queen {
 
     }
 
-    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
+    fn invalid_moves(&self, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
         let invalids = HashSet::new();
+
+        return invalids;
+    }
+
+    fn prune_moves(initial_pos: &Position, row_max: i8, col_max: i8) -> HashSet<Position> {
+        let mut invalids: HashSet<Position> = HashSet::new();
 
         return invalids;
     }

--- a/src/game/pieces/queen.rs
+++ b/src/game/pieces/queen.rs
@@ -19,7 +19,7 @@ impl Queen {
 }
 
 impl Piece for Queen {
-    fn validate_move(new_move: &str) -> bool {
+    fn validate_move(old_pos: &Position, new_pos: &Position) -> bool {
         // TODO: generate all possible moves for this piece. Compare with move.
         // TODO: Turn move to Position, use position comparison
         return true;

--- a/src/game/pieces/queen.rs
+++ b/src/game/pieces/queen.rs
@@ -1,5 +1,6 @@
 use crate::game::side::Side;
 use crate::game::pieces::piece::*;
+use crate::game::move_direction::MoveDirection;
 
 use std::collections::HashSet;
 
@@ -26,5 +27,18 @@ impl Piece for Queen {
         let moves = HashSet::new();
 
         return moves;
+    }
+
+    fn find_prune_direction(&self, pos: &Position, x_diff: u8, y_diff: u8) -> MoveDirection {
+        let dir = MoveDirection::UP;
+
+        return dir;
+
+    }
+
+    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position> {
+        let invalids = HashSet::new();
+
+        return invalids;
     }
 }

--- a/src/game/pieces/rook.rs
+++ b/src/game/pieces/rook.rs
@@ -1,6 +1,9 @@
 use crate::game::side::Side;
 use crate::game::pieces::piece::*;
 
+use std::collections::HashSet;
+
+#[derive(Clone)]
 pub struct Rook {
     pub icon: char,
 
@@ -19,8 +22,8 @@ impl Rook {
 }
 
 impl Piece for Rook {
-    fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position> {
-        let moves = Vec::new();
+    fn possible_moves(&mut self, initial_pos: &Position) -> HashSet<Position> {
+        let moves = HashSet::new();
 
         return moves;
     }

--- a/src/game/pieces/rook.rs
+++ b/src/game/pieces/rook.rs
@@ -19,9 +19,9 @@ impl Rook {
 }
 
 impl Piece for Rook {
-    fn validate_move(old_pos: &Position, new_pos: &Position) -> bool {
-        // TODO: generate all possible moves for this piece. Compare with move.
-        // TODO: Turn move to Position, use position comparison
-        return true;
+    fn possible_moves(&mut self, initial_pos: &Position) -> Vec<Position> {
+        let moves = Vec::new();
+
+        return moves;
     }
 }

--- a/src/game/pieces/rook.rs
+++ b/src/game/pieces/rook.rs
@@ -19,7 +19,7 @@ impl Rook {
 }
 
 impl Piece for Rook {
-    fn validate_move(new_move: &str) -> bool {
+    fn validate_move(old_pos: &Position, new_pos: &Position) -> bool {
         // TODO: generate all possible moves for this piece. Compare with move.
         // TODO: Turn move to Position, use position comparison
         return true;

--- a/src/game/pieces/rook.rs
+++ b/src/game/pieces/rook.rs
@@ -29,14 +29,14 @@ impl Piece for Rook {
         return moves;
     }
 
-    fn find_prune_direction(&self, pos: &Position, x_diff: u8, y_diff: u8) -> MoveDirection {
+    fn find_prune_direction(&self, pos: &Position, x_diff: i8, y_diff: i8) -> MoveDirection {
         let dir = MoveDirection::UP;
 
         return dir;
 
     }
 
-    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position> {
+    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
         let invalids = HashSet::new();
 
         return invalids;

--- a/src/game/pieces/rook.rs
+++ b/src/game/pieces/rook.rs
@@ -1,5 +1,6 @@
 use crate::game::side::Side;
 use crate::game::pieces::piece::*;
+use crate::game::move_direction::MoveDirection;
 
 use std::collections::HashSet;
 
@@ -26,5 +27,18 @@ impl Piece for Rook {
         let moves = HashSet::new();
 
         return moves;
+    }
+
+    fn find_prune_direction(&self, pos: &Position, x_diff: u8, y_diff: u8) -> MoveDirection {
+        let dir = MoveDirection::UP;
+
+        return dir;
+
+    }
+
+    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: u8, y_diff: u8) -> HashSet<Position> {
+        let invalids = HashSet::new();
+
+        return invalids;
     }
 }

--- a/src/game/pieces/rook.rs
+++ b/src/game/pieces/rook.rs
@@ -36,8 +36,14 @@ impl Piece for Rook {
 
     }
 
-    fn invalid_moves(&self, possible_moves: &HashSet<Position>, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
+    fn invalid_moves(&self, pos: &Position, x_diff: i8, y_diff: i8) -> HashSet<Position> {
         let invalids = HashSet::new();
+
+        return invalids;
+    }
+
+    fn prune_moves(initial_pos: &Position, row_max: i8, col_max: i8) -> HashSet<Position> {
+        let mut invalids: HashSet<Position> = HashSet::new();
 
         return invalids;
     }

--- a/src/game/player.rs
+++ b/src/game/player.rs
@@ -47,7 +47,7 @@ impl Player {
         return map;
     }
 
-    pub fn move_input(&self) -> Option<(Position, Position)> {
+    pub fn move_input(&mut self) -> Option<(Position, Position)> {
         let (initial_pos, result_pos): (Position, Position);
         loop {
             let mut new_move = String::new();
@@ -77,6 +77,10 @@ impl Player {
         return self.pieces.get(&pos);
     }
 
+    pub fn get_piece_mut(&mut self, pos: &Position) -> Option<&mut PieceType> {
+        return self.pieces.get_mut(&pos);
+    }
+
     pub fn apply_move(&mut self, initial_pos: &Position, result_pos: &Position) {
         assert!(self.pieces.contains_key(initial_pos), "None of the players pieces are located at the initial position");
 
@@ -101,7 +105,7 @@ impl Player {
         self.pieces.clear();
     }
 
-    fn validate_input(&self, input: &str) -> Result<(Position, Position), String> {
+    fn validate_input(&mut self, input: &str) -> Result<(Position, Position), String> {
         if input.len() != 4 { 
             return Err("Move must follow the example format: a1a2".to_string());
         }
@@ -124,18 +128,18 @@ impl Player {
         let old_pos = Position { x: old_pos_x, y: old_pos_y };
         let new_pos = Position { x: new_pos_x, y: new_pos_y };
 
-        let piece_search = self.get_piece(&old_pos);
+        let piece_search = self.get_piece_mut(&old_pos);
         if let Some(piece) = piece_search {
             if !piece.validate_move(&old_pos, &new_pos) {
-                return Err("Move cannot be performed on your selected piece".to_string()); 
+                return Err("Your move on that piece is illegal".to_string()); 
             }
         }
         else if let None = self.get_piece(&old_pos) {
-            return Err("Move must be performed on your  piece".to_string());
+            return Err("Move must be performed on your piece".to_string());
         }
 
         if let Some(_) = self.get_piece(&new_pos) {
-            return Err("Move must not land on another piece of yours.".to_string());
+            return Err("Move must not land on another piece of yours".to_string());
         }
 
         return Ok((old_pos, new_pos));

--- a/src/game/player.rs
+++ b/src/game/player.rs
@@ -125,8 +125,10 @@ impl Player {
         let new_pos = Position { x: new_pos_x, y: new_pos_y };
 
         let piece_search = self.get_piece(&old_pos);
-        if let Some(_piece) = piece_search {
-            // TODO: validate possible moves
+        if let Some(piece) = piece_search {
+            if !piece.validate_move(&old_pos, &new_pos) {
+                return Err("Move cannot be performed on your selected piece".to_string()); 
+            }
         }
         else if let None = self.get_piece(&old_pos) {
             return Err("Move must be performed on your  piece".to_string());

--- a/src/game/player.rs
+++ b/src/game/player.rs
@@ -175,7 +175,7 @@ impl Player {
             let x_diff = (self.current_piece.0.x - found_pos.x) as i8;
             let y_diff = (self.current_piece.0.y - found_pos.y) as i8;
 
-            let mut moves_to_prune = self.current_piece.1.invalid_moves(&self.possible_moves, &self.current_piece.0, x_diff, y_diff);
+            let mut moves_to_prune = self.current_piece.1.invalid_moves(&self.current_piece.0, x_diff, y_diff);
             if !capturing {
                 moves_to_prune.insert(found_pos);
             }

--- a/src/game/player.rs
+++ b/src/game/player.rs
@@ -73,13 +73,8 @@ impl Player {
         return Some((initial_pos, result_pos));
     }
 
-    // TODO: refactor to contains key
-    pub fn piece_at_coord(&self, pos: &Position) -> bool {
-        let mut found = false;
-        if let Some(_value) = self.pieces.get(pos) {
-            found = true;
-        }
-        return found;
+    pub fn get_piece(&self, pos: &Position) -> Option<&PieceType> {
+        return self.pieces.get(&pos);
     }
 
     pub fn apply_move(&mut self, initial_pos: &Position, result_pos: &Position) {
@@ -129,11 +124,15 @@ impl Player {
         let old_pos = Position { x: old_pos_x, y: old_pos_y };
         let new_pos = Position { x: new_pos_x, y: new_pos_y };
 
-        if !self.piece_at_coord(&old_pos) {
+        let piece_search = self.get_piece(&old_pos);
+        if let Some(_piece) = piece_search {
+            // TODO: validate possible moves
+        }
+        else if let None = self.get_piece(&old_pos) {
             return Err("Move must be performed on your  piece".to_string());
         }
 
-        if self.piece_at_coord(&new_pos) {
+        if let Some(_) = self.get_piece(&new_pos) {
             return Err("Move must not land on another piece of yours.".to_string());
         }
 

--- a/src/game/player.rs
+++ b/src/game/player.rs
@@ -47,8 +47,8 @@ impl Player {
         return map;
     }
 
-    pub fn move_input(&self) -> (Position, Position) {
-        let (mut initial_pos, mut result_pos) = (Position { x: -1, y: -1 }, Position { x: -1, y: -1 });
+    pub fn move_input(&self) -> Option<(Position, Position)> {
+        let (initial_pos, result_pos): (Position, Position);
         loop {
             let mut new_move = String::new();
             io::stdin().read_line(&mut new_move)
@@ -56,7 +56,7 @@ impl Player {
             new_move = new_move.trim().to_string();
 
             if new_move == "menu" {
-                break;
+                return None;
             }
 
             let validation = self.validate_input(&new_move);
@@ -70,7 +70,7 @@ impl Player {
             }
         }
 
-        return (initial_pos, result_pos);
+        return Some((initial_pos, result_pos));
     }
 
     // TODO: refactor to contains key

--- a/src/game/player.rs
+++ b/src/game/player.rs
@@ -143,10 +143,6 @@ impl Player {
         return self.pieces.get(&pos);
     }
 
-    pub fn get_piece_mut(&mut self, pos: &Position) -> Option<&mut PieceType> {
-        return self.pieces.get_mut(&pos);
-    }
-
     pub fn add_piece(&mut self, pos: Position, piece: PieceType) {
         assert!(pos.x < 8 && pos.y < 8, "Adding piece at position ({},{}) that lies off the board", pos.x, pos.y);
         assert!(!self.pieces.contains_key(&pos), "Adding a piece at a position ({},{}) which already contains a piece", pos.x, pos.y);
@@ -176,8 +172,8 @@ impl Player {
 
             let found_pos = *piece_in_path;
 
-            let x_diff = (self.current_piece.0.x - found_pos.x) as u8;
-            let y_diff = (self.current_piece.0.y - found_pos.y) as u8;
+            let x_diff = (self.current_piece.0.x - found_pos.x) as i8;
+            let y_diff = (self.current_piece.0.y - found_pos.y) as i8;
 
             let mut moves_to_prune = self.current_piece.1.invalid_moves(&self.possible_moves, &self.current_piece.0, x_diff, y_diff);
             if !capturing {


### PR DESCRIPTION
Defined a common structure for piecewise move validation:
- collect all moves
- prune moves that cannot be performed according to player pieces
- prune moves that cannot be performed according to opponent pieces

Bishop pruning methods implemented